### PR TITLE
[Cookies] Adds a feature to check max possible balance of cookies

### DIFF
--- a/cookies/cookies.py
+++ b/cookies/cookies.py
@@ -7,13 +7,14 @@ from typing import Any, Union
 from discord.utils import get
 from datetime import datetime
 
-from redbot.core.bank import _MAX_BALANCE
 from redbot.core import Config, checks, commands
 from redbot.core.utils.chat_formatting import pagify, box
 from redbot.core.utils.predicates import MessagePredicate
 from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
 
 from redbot.core.bot import Red
+
+_MAX_BALANCE = 2 ** 63 - 1
 
 
 class Cookies(commands.Cog):


### PR DESCRIPTION
Hey thanks for this cog first, users really enjoy it!

So, this PR adds a feature to check max balance of cookies, `_MAX_BALANCE` is something from redbot.core.bank in dev, that's why I haven't imported the actual one since it'll change.
So basically members can't get more than `9,223,372,036,854,775,807` cookies.
It's to avoid weird things happens since JSON module used in Red doesn't check for this max int.