### PR TITLE
[CookieStore, Forwarding, Pingable] Disable role mention auto-sanitizer when sending pinging message

### DIFF
--- a/cookiestore/cookiestore.py
+++ b/cookiestore/cookiestore.py
@@ -6,6 +6,7 @@ from typing import Any, Union, Optional
 from discord.utils import get
 from datetime import datetime
 
+from redbot import VersionInfo, version_info
 from redbot.core import Config, checks, commands
 from redbot.core.utils.chat_formatting import pagify, box, humanize_list
 from redbot.core.utils.predicates import MessagePredicate
@@ -15,6 +16,10 @@ from redbot.core.bot import Red
 
 Cog: Any = getattr(commands, "Cog", object)
 
+if version_info < VersionInfo.from_str("3.3.2"):
+    SANITIZE_ROLES_KWARG = {}
+else:
+    SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
 class CookieStore(Cog):
     """
@@ -679,12 +684,12 @@ class CookieStore(Cog):
             if not ping.mentionable:
                 await ping.edit(mentionable=True)
                 await ctx.send(
-                    f"{ping.mention}, {ctx.author.mention} would like to redeem {item}."
+                    f"{ping.mention}, {ctx.author.mention} would like to redeem {item}.", **SANITIZE_ROLES_KWARG
                 )
                 await ping.edit(mentionable=False)
             else:
                 await ctx.send(
-                    f"{ping.mention}, {ctx.author.mention} would like to redeem {item}."
+                    f"{ping.mention}, {ctx.author.mention} would like to redeem {item}.", **SANITIZE_ROLES_KWARG
                 )
             await self.config.member(ctx.author).inventory.set_raw(
                 item, "redeemed", value=True

--- a/forwarding/forwarding.py
+++ b/forwarding/forwarding.py
@@ -2,6 +2,7 @@ import discord
 
 from discord.utils import get
 
+from redbot import VersionInfo, version_info
 from redbot.core import Config, commands, checks
 
 from redbot.core.bot import Red
@@ -9,6 +10,10 @@ from typing import Any, Union
 
 Cog: Any = getattr(commands, "Cog", object)
 
+if version_info < VersionInfo.from_str("3.3.2"):
+    SANITIZE_ROLES_KWARG = {}
+else:
+    SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
 class Forwarding(commands.Cog):
     """Forward messages to the bot owner, incl. pictures (max one per message).
@@ -43,10 +48,10 @@ class Forwarding(commands.Cog):
             return await channel.send(content=f"{ping_user.mention}", embed=embed)
         if not ping_role.mentionable:
             await ping_role.edit(mentionable=True)
-            await channel.send(content=f"{ping_role.mention}", embed=embed)
+            await channel.send(content=f"{ping_role.mention}", embed=embed, **SANITIZE_ROLES_KWARG)
             await ping_role.edit(mentionable=False)
         else:
-            await channel.send(content=f"{ping_role.mention}", embed=embed)
+            await channel.send(content=f"{ping_role.mention}", embed=embed, **SANITIZE_ROLES_KWARG)
 
     @commands.Cog.listener()
     async def on_message_without_command(self, message):

--- a/pingable/pingable.py
+++ b/pingable/pingable.py
@@ -4,7 +4,7 @@ import discord
 from typing import Any
 from datetime import datetime, timedelta
 
-from redbot.core import VersionInfo, version_info
+from redbot import VersionInfo, version_info
 from redbot.core import Config, checks, commands
 from redbot.core.utils.predicates import MessagePredicate
 from redbot.core.utils.antispam import AntiSpam

--- a/pingable/pingable.py
+++ b/pingable/pingable.py
@@ -4,6 +4,7 @@ import discord
 from typing import Any
 from datetime import datetime, timedelta
 
+from redbot.core import VersionInfo, version_info
 from redbot.core import Config, checks, commands
 from redbot.core.utils.predicates import MessagePredicate
 from redbot.core.utils.antispam import AntiSpam
@@ -12,6 +13,10 @@ from redbot.core.bot import Red
 
 Cog: Any = getattr(commands, "Cog", object)
 
+if version_info < VersionInfo.from_str("3.3.2"):
+    SANITIZE_ROLES_KWARG = {}
+else:
+    SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
 class Pingable(Cog):
     """
@@ -90,7 +95,7 @@ class Pingable(Cog):
         if ctx.author not in self.antispam[ctx.guild]:
             self.antispam[ctx.guild][ctx.author] = AntiSpam([(timedelta(hours=1), 1)])
         if self.antispam[ctx.guild][ctx.author].spammy:
-            return await ctx.send("Uh oh, you're doing this way too frequently.")
+            return await ctx.send("Uh oh, you're doing this way too frequently.", **SANITIZE_ROLES_KWARG)
         await ctx.message.delete()
         await role.edit(mentionable=True)
         await ctx.send(f"{role.mention}\n{ctx.author.mention}: {message}")


### PR DESCRIPTION
Starting with Red 3.3.2, `ctx.send` will automatically sanitize role mentions in message's content to avoid mass-mentioning people by accident. This behavior can be disabled with `sanitize_roles` kwarg set to `False`.
This PR adds that kwarg to `ctx.send` call when Red version is higher than or equal to 3.3.2.
This version hasn't been released just yet, but the change was already merged in develop version which means it's a matter of max few days before the 3.3.2 release happens so you might be interested in having the fix ready in time and this PR keeps the backwards-compatibility so you don't have to worry about merging it before the release.