### PR TITLE
[Pingable] Fix the version number of the sanitize_roles change

### DIFF
--- a/cookiestore/cookiestore.py
+++ b/cookiestore/cookiestore.py
@@ -16,7 +16,7 @@ from redbot.core.bot import Red
 
 Cog: Any = getattr(commands, "Cog", object)
 
-if version_info < VersionInfo.from_str("3.3.2"):
+if version_info < VersionInfo.from_str("3.4.0"):
     SANITIZE_ROLES_KWARG = {}
 else:
     SANITIZE_ROLES_KWARG = {"sanitize_roles": False}

--- a/forwarding/forwarding.py
+++ b/forwarding/forwarding.py
@@ -10,7 +10,7 @@ from typing import Any, Union
 
 Cog: Any = getattr(commands, "Cog", object)
 
-if version_info < VersionInfo.from_str("3.3.2"):
+if version_info < VersionInfo.from_str("3.4.0"):
     SANITIZE_ROLES_KWARG = {}
 else:
     SANITIZE_ROLES_KWARG = {"sanitize_roles": False}

--- a/pingable/pingable.py
+++ b/pingable/pingable.py
@@ -13,7 +13,7 @@ from redbot.core.bot import Red
 
 Cog: Any = getattr(commands, "Cog", object)
 
-if version_info < VersionInfo.from_str("3.3.2"):
+if version_info < VersionInfo.from_str("3.4.0"):
     SANITIZE_ROLES_KWARG = {}
 else:
     SANITIZE_ROLES_KWARG = {"sanitize_roles": False}


### PR DESCRIPTION
Hi,
this is a follow up to #9, it turned out that 3.3.2 release will in fact be 3.4.0 release as people in Red decided that this change should be considered breaking after all.
This shouldn't really matter cause the check you have there already works for anything past 3.2.2 and that includes 3.4.0, but it might clearer for people looking at this code in the future.