### PR TITLE
Remove pre-3.0 compatibility and remove incorrect 3.4+ compatibility layer

### DIFF
--- a/advancedlock/advancedlock.py
+++ b/advancedlock/advancedlock.py
@@ -1,7 +1,6 @@
 import asyncio
 import discord
 
-from typing import Any
 from discord.utils import get
 from datetime import datetime
 
@@ -11,10 +10,8 @@ from redbot.core.utils.chat_formatting import humanize_list
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class AdvancedLock(Cog):
+class AdvancedLock(commands.Cog):
     """
     Lock `@everyone` from sending messages.
     Use `[p]setlock setup` first.

--- a/application/application.py
+++ b/application/application.py
@@ -1,7 +1,6 @@
 import asyncio
 import discord
 
-from typing import Any
 from discord.utils import get
 from datetime import datetime, timedelta
 
@@ -11,10 +10,8 @@ from redbot.core.utils.antispam import AntiSpam
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class Application(Cog):
+class Application(commands.Cog):
     """
     Simple application cog, basically.
     **Use `[p]applysetup` first.**

--- a/cookiestore/cookiestore.py
+++ b/cookiestore/cookiestore.py
@@ -1,14 +1,13 @@
 import asyncio
 import discord
-import random
 
-from typing import Union, Optional
+from typing import Union
 from discord.utils import get
 from datetime import datetime
 
 from redbot import VersionInfo, version_info
 from redbot.core import Config, checks, commands
-from redbot.core.utils.chat_formatting import pagify, box, humanize_list
+from redbot.core.utils.chat_formatting import pagify, humanize_list
 from redbot.core.utils.predicates import MessagePredicate
 from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
 

--- a/cookiestore/cookiestore.py
+++ b/cookiestore/cookiestore.py
@@ -2,7 +2,7 @@ import asyncio
 import discord
 import random
 
-from typing import Any, Union, Optional
+from typing import Union, Optional
 from discord.utils import get
 from datetime import datetime
 
@@ -14,14 +14,13 @@ from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
-
 if version_info < VersionInfo.from_str("3.4.0"):
     SANITIZE_ROLES_KWARG = {}
 else:
     SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
-class CookieStore(Cog):
+
+class CookieStore(commands.Cog):
     """
     Store add-on for SauriCogs' Cookies cog.
     """

--- a/cookiestore/cookiestore.py
+++ b/cookiestore/cookiestore.py
@@ -5,18 +5,12 @@ from typing import Union
 from discord.utils import get
 from datetime import datetime
 
-from redbot import VersionInfo, version_info
 from redbot.core import Config, checks, commands
 from redbot.core.utils.chat_formatting import pagify, humanize_list
 from redbot.core.utils.predicates import MessagePredicate
 from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
 
 from redbot.core.bot import Red
-
-if version_info < VersionInfo.from_str("3.4.0"):
-    SANITIZE_ROLES_KWARG = {}
-else:
-    SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
 
 class CookieStore(commands.Cog):
@@ -683,12 +677,12 @@ class CookieStore(commands.Cog):
             if not ping.mentionable:
                 await ping.edit(mentionable=True)
                 await ctx.send(
-                    f"{ping.mention}, {ctx.author.mention} would like to redeem {item}.", **SANITIZE_ROLES_KWARG
+                    f"{ping.mention}, {ctx.author.mention} would like to redeem {item}."
                 )
                 await ping.edit(mentionable=False)
             else:
                 await ctx.send(
-                    f"{ping.mention}, {ctx.author.mention} would like to redeem {item}.", **SANITIZE_ROLES_KWARG
+                    f"{ping.mention}, {ctx.author.mention} would like to redeem {item}."
                 )
             await self.config.member(ctx.author).inventory.set_raw(
                 item, "redeemed", value=True

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -1,7 +1,6 @@
 import asyncio
 import discord
 
-from typing import Any
 from discord.utils import get, find
 from datetime import datetime, timedelta
 
@@ -10,10 +9,8 @@ from redbot.core.utils.antispam import AntiSpam
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class Counting(Cog):
+class Counting(commands.Cog):
     """
     Counting channel!
     """

--- a/counting/counting.py
+++ b/counting/counting.py
@@ -2,10 +2,8 @@ import asyncio
 import discord
 
 from discord.utils import get, find
-from datetime import datetime, timedelta
 
 from redbot.core import Config, checks, commands
-from redbot.core.utils.antispam import AntiSpam
 
 from redbot.core.bot import Red
 

--- a/economyraffle/economyraffle.py
+++ b/economyraffle/economyraffle.py
@@ -1,6 +1,5 @@
 import asyncio
 import random
-import discord
 
 from discord.utils import get
 

--- a/economyraffle/economyraffle.py
+++ b/economyraffle/economyraffle.py
@@ -2,7 +2,6 @@ import asyncio
 import random
 import discord
 
-from typing import Any
 from discord.utils import get
 
 from redbot.core import Config, checks, bank, commands
@@ -10,10 +9,8 @@ from redbot.core.utils.predicates import MessagePredicate
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class EconomyRaffle(Cog):
+class EconomyRaffle(commands.Cog):
     """
     Simple economy raffle cog.
     **Use `[p]economysetup` first.**

--- a/forwarding/forwarding.py
+++ b/forwarding/forwarding.py
@@ -2,16 +2,9 @@ import discord
 
 from discord.utils import get
 
-from redbot import VersionInfo, version_info
 from redbot.core import Config, commands, checks
 
-from redbot.core.bot import Red
 from typing import Union
-
-if version_info < VersionInfo.from_str("3.4.0"):
-    SANITIZE_ROLES_KWARG = {}
-else:
-    SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
 
 class Forwarding(commands.Cog):
@@ -47,10 +40,10 @@ class Forwarding(commands.Cog):
             return await channel.send(content=f"{ping_user.mention}", embed=embed)
         if not ping_role.mentionable:
             await ping_role.edit(mentionable=True)
-            await channel.send(content=f"{ping_role.mention}", embed=embed, **SANITIZE_ROLES_KWARG)
+            await channel.send(content=f"{ping_role.mention}", embed=embed)
             await ping_role.edit(mentionable=False)
         else:
-            await channel.send(content=f"{ping_role.mention}", embed=embed, **SANITIZE_ROLES_KWARG)
+            await channel.send(content=f"{ping_role.mention}", embed=embed)
 
     @commands.Cog.listener()
     async def on_message_without_command(self, message):

--- a/forwarding/forwarding.py
+++ b/forwarding/forwarding.py
@@ -6,14 +6,13 @@ from redbot import VersionInfo, version_info
 from redbot.core import Config, commands, checks
 
 from redbot.core.bot import Red
-from typing import Any, Union
-
-Cog: Any = getattr(commands, "Cog", object)
+from typing import Union
 
 if version_info < VersionInfo.from_str("3.4.0"):
     SANITIZE_ROLES_KWARG = {}
 else:
     SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
+
 
 class Forwarding(commands.Cog):
     """Forward messages to the bot owner, incl. pictures (max one per message).

--- a/gallery/gallery.py
+++ b/gallery/gallery.py
@@ -2,16 +2,12 @@ import asyncio
 import discord
 import re
 
-from typing import Any
-
 from redbot.core import Config, checks, commands
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class Gallery(Cog):
+class Gallery(commands.Cog):
     """
     Gallery channels!
     """

--- a/lock/lock.py
+++ b/lock/lock.py
@@ -1,7 +1,6 @@
 import asyncio
 import discord
 
-from typing import Any
 from discord.utils import get
 
 from redbot.core import Config, checks, commands
@@ -9,10 +8,8 @@ from redbot.core.utils.predicates import MessagePredicate
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class Lock(Cog):
+class Lock(commands.Cog):
     """
     Lock `@everyone` from sending messages.
     Use `[p]locksetup` first.

--- a/lvlupcookies/lvlupcookies.py
+++ b/lvlupcookies/lvlupcookies.py
@@ -1,8 +1,5 @@
-import asyncio
 import discord
-import pymongo
 
-from discord.utils import get
 from pymongo import MongoClient
 from datetime import datetime
 

--- a/lvlupcookies/lvlupcookies.py
+++ b/lvlupcookies/lvlupcookies.py
@@ -2,7 +2,6 @@ import asyncio
 import discord
 import pymongo
 
-from typing import Any
 from discord.utils import get
 from pymongo import MongoClient
 from datetime import datetime
@@ -16,10 +15,8 @@ from redbot.core.bot import Red
 client = MongoClient()
 db = client["leveler"]
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class LevelUpCookies(Cog):
+class LevelUpCookies(commands.Cog):
     """
     Set cookie rewards for users that level up!
 

--- a/marriage/marriage.py
+++ b/marriage/marriage.py
@@ -2,8 +2,6 @@ import discord
 import asyncio
 import random
 
-from typing import Any
-
 from redbot.core import Config, checks, commands, bank
 from redbot.core.utils.chat_formatting import humanize_list
 from redbot.core.utils.predicates import MessagePredicate
@@ -12,10 +10,8 @@ from redbot.core.bot import Red
 
 __author__ = "saurichable"
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class Marriage(Cog):
+class Marriage(commands.Cog):
     """
     Marriage cog with some extra shit
     """

--- a/mentionable/mentionable.py
+++ b/mentionable/mentionable.py
@@ -1,7 +1,5 @@
 import discord
 
-from discord.utils import get
-
 from redbot.core import checks, commands
 
 from redbot.core.bot import Red

--- a/mentionable/mentionable.py
+++ b/mentionable/mentionable.py
@@ -5,12 +5,9 @@ from discord.utils import get
 from redbot.core import checks, commands
 
 from redbot.core.bot import Red
-from typing import Any
-
-Cog: Any = getattr(commands, "Cog", object)
 
 
-class Mentionable(Cog):
+class Mentionable(commands.Cog):
     """
     Makes unmentionable roles mentionable.
     """

--- a/pick/pick.py
+++ b/pick/pick.py
@@ -1,17 +1,14 @@
 import random
 import discord
 
-from typing import Any
 from discord.utils import get
 
 from redbot.core import Config, checks, commands
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class Pick(Cog):
+class Pick(commands.Cog):
     """Pick a random user or a user with a specified role. For the latter, use `[p]pickrole <role>` first.
     **Output is a user ID.**
     I suggest using it along with [nestedcommands](https://github.com/tmercswims/tmerc-cogs) and [scheduler](https://github.com/mikeshardmind/SinbadCogs)."""

--- a/pick/pick.py
+++ b/pick/pick.py
@@ -5,8 +5,6 @@ from discord.utils import get
 
 from redbot.core import Config, checks, commands
 
-from redbot.core.bot import Red
-
 
 class Pick(commands.Cog):
     """Pick a random user or a user with a specified role. For the latter, use `[p]pickrole <role>` first.

--- a/pingable/pingable.py
+++ b/pingable/pingable.py
@@ -1,7 +1,6 @@
 import asyncio
 import discord
 
-from typing import Any
 from datetime import datetime, timedelta
 
 from redbot import VersionInfo, version_info
@@ -11,14 +10,13 @@ from redbot.core.utils.antispam import AntiSpam
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
-
 if version_info < VersionInfo.from_str("3.4.0"):
     SANITIZE_ROLES_KWARG = {}
 else:
     SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
-class Pingable(Cog):
+
+class Pingable(commands.Cog):
     """
     Make unpingable roles pingable by regular users with commands.
     """

--- a/pingable/pingable.py
+++ b/pingable/pingable.py
@@ -3,17 +3,11 @@ import discord
 
 from datetime import timedelta
 
-from redbot import VersionInfo, version_info
 from redbot.core import Config, checks, commands
 from redbot.core.utils.predicates import MessagePredicate
 from redbot.core.utils.antispam import AntiSpam
 
 from redbot.core.bot import Red
-
-if version_info < VersionInfo.from_str("3.4.0"):
-    SANITIZE_ROLES_KWARG = {}
-else:
-    SANITIZE_ROLES_KWARG = {"sanitize_roles": False}
 
 
 class Pingable(commands.Cog):
@@ -93,7 +87,7 @@ class Pingable(commands.Cog):
         if ctx.author not in self.antispam[ctx.guild]:
             self.antispam[ctx.guild][ctx.author] = AntiSpam([(timedelta(hours=1), 1)])
         if self.antispam[ctx.guild][ctx.author].spammy:
-            return await ctx.send("Uh oh, you're doing this way too frequently.", **SANITIZE_ROLES_KWARG)
+            return await ctx.send("Uh oh, you're doing this way too frequently.")
         await ctx.message.delete()
         await role.edit(mentionable=True)
         await ctx.send(f"{role.mention}\n{ctx.author.mention}: {message}")

--- a/pingable/pingable.py
+++ b/pingable/pingable.py
@@ -1,7 +1,7 @@
 import asyncio
 import discord
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from redbot import VersionInfo, version_info
 from redbot.core import Config, checks, commands

--- a/suggestion/suggestion.py
+++ b/suggestion/suggestion.py
@@ -3,7 +3,7 @@ import discord
 
 from typing import Optional
 from discord.utils import get
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from redbot.core import Config, checks, commands
 from redbot.core.utils.predicates import MessagePredicate, ReactionPredicate

--- a/suggestion/suggestion.py
+++ b/suggestion/suggestion.py
@@ -1,7 +1,7 @@
 import asyncio
 import discord
 
-from typing import Any, Optional
+from typing import Optional
 from discord.utils import get
 from datetime import datetime, timedelta
 
@@ -12,10 +12,8 @@ from redbot.core.utils.antispam import AntiSpam
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class Suggestion(Cog):
+class Suggestion(commands.Cog):
     """
     Simple suggestion box, basically.
 

--- a/uniquename/uniquename.py
+++ b/uniquename/uniquename.py
@@ -1,10 +1,6 @@
 import discord
 
-from discord.utils import get
-
 from redbot.core import Config, checks, commands
-
-from redbot.core.bot import Red
 
 
 class UniqueName(commands.Cog):

--- a/uniquename/uniquename.py
+++ b/uniquename/uniquename.py
@@ -1,16 +1,13 @@
 import discord
 
-from typing import Any
 from discord.utils import get
 
 from redbot.core import Config, checks, commands
 
 from redbot.core.bot import Red
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class UniqueName(Cog):
+class UniqueName(commands.Cog):
     """Deny members' names to be the same as your Moderators'."""
 
     __author__ = "saurichable"

--- a/userlog/userlog.py
+++ b/userlog/userlog.py
@@ -1,18 +1,14 @@
 import datetime
 import discord
 
-from typing import Any
-
 from redbot.core import checks, commands, Config
 
 from redbot.core.bot import Red
 
 __author__ = "saurichable"
 
-Cog: Any = getattr(commands, "Cog", object)
 
-
-class UserLog(Cog):
+class UserLog(commands.Cog):
     """Log when users join/leave into your specified channel."""
 
     __author__ = "saurichable"


### PR DESCRIPTION
Reds older than 3.3.10 crash due to the d.py bug so there's no need to keep the compatibility layer from before 3.0.0 release.
As for the 3.4.0 compatibility layer that I have contributed in the past... `sanitize_roles` kwarg is no longer planned as discord gave us native way to specify allowed mentions. I simply removed the compatibility layer, as I'm not sure how you will want to handle - you *could* for example just drop pre-3.4 support (when 3.4 gets released that is) and use the cool allowed_mentions feature along with Mention Everyone perm on the bot which now allows the bot to ping any role or maybe you will want to use separate logics for pre-3.4 and post-3.4 or *maybe* you will do something else ¯\_(ツ)_/¯

I also removed unused imports, but that was just cause I noticed you have those.