### PR TITLE
[Forwarding] don't forward blacklisted users

### DIFF
--- a/forwarding/forwarding.py
+++ b/forwarding/forwarding.py
@@ -53,6 +53,8 @@ class Forwarding(commands.Cog):
             return
         if message.author == self.bot.user:
             return
+        if not (await self.bot.allowed_by_whitelist_blacklist(message.author)):
+            return
         if not message.attachments:
             embed = discord.Embed(
                 colour=discord.Colour.red(),


### PR DESCRIPTION
Stops the Forwarding from forwarding anything from blacklisted / non-whitelisted users.

Addresses #35
> Or the ability to block them entirely.