### PR TITLE
Fix uninitialized variable

### DIFF
--- a/uniquename/uniquename.py
+++ b/uniquename/uniquename.py
@@ -58,6 +58,7 @@ class UniqueName(commands.Cog):
     @uniquenameset.command(name="roles")
     async def unset_roles(self, ctx: commands.Context):
         """View the protected roles."""
+        guild = ctx.guild
         roles = []
         for rid in await self.config.guild(guild).roles():
             role = guild.get_role(rid)


### PR DESCRIPTION
There is an uninitialized variable resulting in an error in the [p]unset roles command.